### PR TITLE
ensure bot has non-default username

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -167,9 +167,14 @@ Array.prototype.randomItem = function() {
 function setup() {
     if (CLIENT.get("nick") !== botnick)
     {
-        CLIENT.submit("/nick " + botnick);
         CLIENT.submit("/login bottybot " + botnick);
     }
+    //if the bot is still not logged in, try /nick
+    if (CLIENT.get("nick") !== botnick)
+    {
+        CLIENT.submit("/nick " + botnick);
+    }
+
     CLIENT.submit("/safe");
     CLIENT.set("part", "to get repaired by Bruno");
     CLIENT.set("mask", "brunos.secret.bot.laboratory");

--- a/bot.js
+++ b/bot.js
@@ -166,7 +166,10 @@ Array.prototype.randomItem = function() {
 // Username popup and flair setter, basic setup
 function setup() {
     if (CLIENT.get("nick") !== botnick)
+    {
+        CLIENT.submit("/nick " + botnick);
         CLIENT.submit("/login bottybot " + botnick);
+    }
     CLIENT.submit("/safe");
     CLIENT.set("part", "to get repaired by Bruno");
     CLIENT.set("mask", "brunos.secret.bot.laboratory");


### PR DESCRIPTION
As of june 9 2015 at 12:43 EST, masterbot is anonymous
The bot only ever tries /login, not /nick, so if it's not registered with the password "bottybot" it will remain anonymous
This patch makes the bot try /nick botname if its name is not botname after the /login command